### PR TITLE
"interface-over-type-literal": false

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -32,7 +32,8 @@
     "max-classes-per-file": [true, 3],
     "no-var-requires": false,
     "member-ordering": false,
-    "no-floating-promises": true
+    "no-floating-promises": true,
+    "interface-over-type-literal": false
   },
 
   "jsRules": {


### PR DESCRIPTION
Justification: there are many times (and @XVincentX would probably agree with me) when it makes more sense to export a type alias rather than an interface. Semantically, I think of an `interface` as a thing meant to be implemented / extended. If I'm just documenting a return type of a function (or a postMessage message format), like `{ result: string, err?: { code: number, msg: string} }`, it feels wrong to declare it as an "interface".